### PR TITLE
actually call InformSQVMDestroyed

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -258,6 +258,8 @@ template <ScriptContext context> void SquirrelManager<context>::VMCreated(CSquir
 
 template <ScriptContext context> void SquirrelManager<context>::VMDestroyed()
 {
+	g_pPluginManager->InformSQVMDestroyed(context);
+
 	m_pSQVM = nullptr;
 }
 


### PR DESCRIPTION
This would call `InformSQVMDestroyed` when sqvm is destroyed.

the class creating function isn't in this pr since I am unsure if I actually need it.