### PR TITLE
Add CreateObject function

### DIFF
--- a/NorthstarDLL/plugins/plugin_abi.h
+++ b/NorthstarDLL/plugins/plugin_abi.h
@@ -19,6 +19,12 @@ enum PluginLoadDLL
 	SERVER
 };
 
+enum ObjectType
+{
+	CONCOMMANDS = 0,
+	CONVAR = 1,
+};
+
 struct SquirrelFunctions
 {
 	RegisterSquirrelFuncType RegisterSquirrelFunc;
@@ -85,6 +91,7 @@ struct LogMsg
 
 typedef void (*loggerfunc_t)(LogMsg* msg);
 typedef void (*PLUGIN_RELAY_INVITE_TYPE)(const char* invite);
+typedef void* (*CreateObjectFunc)(ObjectType type);
 
 struct PluginNorthstarData
 {
@@ -97,6 +104,7 @@ struct PluginInitFuncs
 {
 	loggerfunc_t logger;
 	PLUGIN_RELAY_INVITE_TYPE relayInviteFunc;
+	CreateObjectFunc createObject;
 };
 
 struct PluginEngineData

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -36,6 +36,17 @@ EXPORT void PLUGIN_LOG(LogMsg* msg)
 	logger->log(src, (spdlog::level::level_enum)msg->level, msg->msg);
 }
 
+EXPORT void* CreateObject(ObjectType type)
+{
+	switch (type)
+	{
+	case ObjectType::CONVAR:
+		return (void*)new ConVar;
+	case ObjectType::CONCOMMANDS:
+		return (void*)new ConCommand;
+	}
+}
+
 std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* funcs, PluginNorthstarData* data)
 {
 
@@ -189,6 +200,7 @@ bool PluginManager::LoadPlugins()
 	PluginInitFuncs funcs {};
 	funcs.logger = PLUGIN_LOG;
 	funcs.relayInviteFunc = nullptr;
+	funcs.createObject = CreateObject;
 
 	init_plugincommunicationhandler();
 


### PR DESCRIPTION
This is the implemented version of the function discussed -> [https://discord.com/channels/920776187884732556/951461326478262292/1059321602166231060](https://discord.com/channels/920776187884732556/951461326478262292/1059321602166231060).

This would generate a zeroed class ( since rust can't create c++ vtables this function is necessary for concomands and convars )

I have tested this and can confirm that it returns the expected class :)